### PR TITLE
Patch renv

### DIFF
--- a/appendices/appendix-B-examples.Rmd
+++ b/appendices/appendix-B-examples.Rmd
@@ -84,7 +84,7 @@ Clone the repository <https://github.com/boettiger-lab/rl-intro>, e.g. using the
 
 From the project directory, we can then install all the necessary dependencies using `renv`, which helps ensure a reproducible environment of fixed versions of R packages and Python modules.
 
-```{r message=FALSE, eval=FALSE}
+```{r message=FALSE}
 #install.packages("renv")
 renv::restore()
 ```

--- a/renv.lock
+++ b/renv.lock
@@ -10,8 +10,7 @@
   },
   "Python": {
     "Version": "3.8.5",
-    "Type": "virtualenv",
-    "Name": null
+    "Type": "virtualenv"
   },
   "Packages": {
     "BH": {
@@ -58,10 +57,10 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.6",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "dbb5e436998a7eba5a9d682060533338"
+      "Hash": "dab19adae4440ae55aa8a9d238b246bb"
     },
     "askpass": {
       "Package": "askpass",
@@ -549,7 +548,9 @@
     "renv": {
       "Package": "renv",
       "Version": "0.14.0",
-      "Source": "Repository"
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "30e5eba91b67f7f4d75d31de14bbfbdc"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv.lock
+++ b/renv.lock
@@ -548,10 +548,8 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.13.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "079cb1f03ff972b30401ed05623cbe92"
+      "Version": "0.14.0",
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,13 +2,27 @@
 local({
 
   # the requested version of renv
-  version <- "0.13.2"
+  version <- "0.14.0"
 
   # the project directory
   project <- getwd()
 
+  # allow environment variable to control activation
+  activate <- Sys.getenv("RENV_ACTIVATE_PROJECT")
+  if (!nzchar(activate)) {
+
+    # don't auto-activate when R CMD INSTALL is running
+    if (nzchar(Sys.getenv("R_INSTALL_PKG")))
+      return(FALSE)
+
+  }
+
+  # bail if activation was explicitly disabled
+  if (tolower(activate) %in% c("false", "f", "0"))
+    return(FALSE)
+
   # avoid recursion
-  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+  if (nzchar(Sys.getenv("RENV_R_INITIALIZING")))
     return(invisible(TRUE))
 
   # signal that we're loading renv during R startup

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ matplotlib==3.4.2
 numpy==1.20.3
 pandas==1.2.4
 Pillow==8.2.0
+pkg_resources==0.0.0
 pyglet==1.5.15
 pyparsing==2.4.7
 python-dateutil==2.8.1


### PR DESCRIPTION
@mlap Okay, Kevin Ushey from RStudio set me straight on our `renv` / CI woes.  Even though the GH-Action installs the latest `renv` from CRAN to begin with, our lockfile fixed renv back at 0.13.2, before some of the python infrastructure was properly hardened.  Looks like bumping the renv version in our lockfile should fix things.  (also had to bump Rcpp version or `library(reticulate)` would fail, not sure why that would be the case but may be related to use of `reticulate` in `renv` for handling the python side of things...)